### PR TITLE
switched sdata link to R

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1549,7 +1549,7 @@ in the following ways.
   * Peter J. Huber, Elvezio M. Ronchetti: Robust Statistics, Concomitant scale estimates, pg 172
 
 Note that this estimator is different from the R implementation of Robust Regression
-(https://stats.oarc.ucla.edu/stata/dae/robust-regression/) because the R implementation does a weighted least
+(https://stats.oarc.ucla.edu/r/dae/robust-regression/) because the R implementation does a weighted least
 squares implementation with weights given to each sample on the basis of how much the residual is
 greater than a certain threshold.
 


### PR DESCRIPTION
Reference Issues/PRs
Fix broken links in the documentation https://github.com/scikit-learn/scikit-learn/issues/23631

What does this implement/fix? Explain your changes.
Fixes http://www.ats.ucla.edu/stat/r/dae/rreg.html broken link in modules/linear_model.rst

by replacing this link with

https://stats.oarc.ucla.edu/r/dae/robust-regression/

Any other comments?

Ah! thanks for the correction, I was going purely based on an initial scan of the data being used to portray the information. 